### PR TITLE
Fix the usage on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Example:
 
 <!-- app/views/posts/show.html.erb -->
 
-<%= render_with_areas do |layout| %>
+<%= render_with_areas 'ui/modal' do |layout| %>
   <% layout.with :header do %>
     <h1>Modal Title</h1>
   <% end %>
@@ -56,7 +56,7 @@ Example:
 
 
 <!-- also supports locals, strings -->
-<%= render_with_areas, title: "Modal Title" do |layout| %>
+<%= render_with_areas 'path/to/partial', title: "Modal Title" do |layout| %>
   This will show up as "content"
 
   <% layout.with :footer, "Footer" %>


### PR DESCRIPTION
## What

Fix the usage on the readme

## Why

The readme is simply wrong 😛 

The first argument should be the partial's path https://github.com/balvig/render_with_areas/blob/7f5ab942f83e10ccda90d18e4419233132f75c90/lib/render_with_areas/content_areas.rb#L3

## How

By fixing the example